### PR TITLE
Steam shortcut - remove forced compatibility tool

### DIFF
--- a/install_palia.sh
+++ b/install_palia.sh
@@ -510,10 +510,11 @@ EndOfMessage
 
     addNonSteamGame	-ep="$(pwd)/$PSH_SCRIPT" -an="$PALIA_TITLE" -ip="$IMGS/$IMG_ICON" -ao=1
 
-    mkdir -p "$SUIC/grid"
-	$COMPATTOOL -c $CFGVDF $shortAppId proton_experimental
-	writelog INFO "main - Set AppID: '$shortAppId' in '$CFGVDF' to 'proton_experimental'"
+    # No need to force compatibility tool, the palia_steam_helper.sh script does that - also avoids creation of unneeded prefix in Steam compatdata
+    #$COMPATTOOL -c $CFGVDF $shortAppId proton_experimental
+    #writelog INFO "main - Set AppID: '$shortAppId' in '$CFGVDF' to 'proton_experimental'"
 
+    mkdir -p "$SUIC/grid"
     setGameArt $shortAppId --hero="$IMGS/$IMG_HERO" --logo="$IMGS/$IMG_LOGO" --boxart="$IMGS/$IMG_BOXART" --tenfoot="$IMGS/$IMG_TENFOOT"
 
     msg "$(cat << EndOfMessage


### PR DESCRIPTION
For the created Steam shortcut that points to palia_steam_helper.sh there is no need to force compatibility tool - it only creates unneeded Proton prefix. The proton stuff is done by the script which is run natively.

install_palia.sh
- removed setting Proton Experimental for newly created shortcut

palia_steam_helper.sh
- moved logging initialization further up so that we can log environment or errors during initialization
- added some comments regarding setting specific environment variables
- allow user to request specific proton compatibility data folder (instead of using ./steam) with PALIA_COMPAT_DATA_PATH environment variable